### PR TITLE
When running on a Windows host, git helpfully checkout *.sh with CRLF…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
… line endings, but docker/bash barfs. Set EOL to LF.